### PR TITLE
Add support for retrieving MRNowPlayingClientGetParentAppBundleIdentifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Output is encoded as JSON and characterized by either `null`
 or a dictionary with any of the following keys:
 
 > `bundleIdentifier`
+`parentAppBundleIdentifier`
 `playing`
 `title`
 `artist`

--- a/include/MediaRemoteAdapter.h
+++ b/include/MediaRemoteAdapter.h
@@ -12,6 +12,7 @@
 // Example: MEDIAREMOTEADAPTER_adapter_send_0_command
 
 extern NSString *kMRABundleIdentifier;
+extern NSString *kMRAParentAppBundleIdentifier;
 extern NSString *kMRAPlaying;
 
 extern NSString *kMRADurationMicros;

--- a/src/adapter/get.m
+++ b/src/adapter/get.m
@@ -21,7 +21,7 @@ void adapter_get() {
 
     id semaphore = dispatch_semaphore_create(0);
 
-    static const int expected_calls = 3;
+    static const int expected_calls = 4;
 
     __block int calls = 0; // thread-safe because the dispatch queue is serial.
     __block NSMutableDictionary *liveData = [NSMutableDictionary dictionary];
@@ -57,6 +57,21 @@ void adapter_get() {
           handle();
       }
     });
+    g_mediaRemote.getNowPlayingClient(
+      g_dispatchQueue, ^(id client) {
+        NSString *parentAppBundleID = nil;
+        if (client &&
+            [client respondsToSelector:@selector(parentApplicationBundleIdentifier)]) {
+            parentAppBundleID = [client
+                performSelector:@selector(parentApplicationBundleIdentifier)];
+        }
+
+        if (parentAppBundleID) {
+            liveData[kMRAParentAppBundleIdentifier] = parentAppBundleID;
+        }
+
+        handle();
+      });
 
     g_mediaRemote.getNowPlayingApplicationIsPlaying(
         g_dispatchQueue, ^(bool isPlaying) {

--- a/src/adapter/keys.m
+++ b/src/adapter/keys.m
@@ -6,6 +6,7 @@
 #import "MediaRemoteAdapter.h"
 
 NSString *kMRABundleIdentifier = @"bundleIdentifier";
+NSString *kMRAParentAppBundleIdentifier = @"parentAppBundleIdentifier";
 NSString *kMRAPlaying = @"playing";
 
 NSString *kMRADurationMicros = @"durationMicros";

--- a/src/adapter/now_playing.h
+++ b/src/adapter/now_playing.h
@@ -11,7 +11,7 @@
 void waitForCommandCompletion();
 
 // Converts raw MediaRemote now playing information to adapter keys.
-// Optionally replaces keys with time valuse with microseconds equivalents.
+// Optionally replaces keys with time values with microseconds equivalents.
 NSMutableDictionary *convertNowPlayingInformation(NSDictionary *information,
                                                   bool convertMicros);
 

--- a/src/private/MediaRemote.h
+++ b/src/private/MediaRemote.h
@@ -109,7 +109,6 @@ extern CFStringRef MRMediaRemoteRegisterForNowPlayingNotifications;
 extern CFStringRef MRMediaRemoteUnregisterForNowPlayingNotifications;
 extern CFStringRef MRMediaRemoteGetNowPlayingApplicationPID;
 extern CFStringRef MRMediaRemoteGetNowPlayingClient;
-extern CFStringRef MRNowPlayingClientGetParentAppBundleIdentifier;
 extern CFStringRef MRMediaRemoteGetNowPlayingInfo;
 extern CFStringRef MRMediaRemoteGetNowPlayingApplicationIsPlaying;
 
@@ -119,12 +118,10 @@ typedef void (*MRMediaRemoteUnregisterForNowPlayingNotifications_t)();
 typedef void (^MRMediaRemoteGetNowPlayingInfoCompletion_t)(NSDictionary *information);
 typedef void (^MRMediaRemoteGetNowPlayingApplicationPIDCompletion_t)(int PID);
 typedef void (^MRMediaRemoteGetNowPlayingClientCompletion_t)(id clientObj);
-typedef void (^MRNowPlayingClientGetParentAppBundleIdentifierCompletion_t)(NSString *bundleIdentifier);
 typedef void (^MRMediaRemoteGetNowPlayingApplicationIsPlayingCompletion_t)(bool isPlaying);
 
 typedef void (*MRMediaRemoteGetNowPlayingApplicationPID_t)(dispatch_queue_t queue, MRMediaRemoteGetNowPlayingApplicationPIDCompletion_t completion);
 typedef void (*MRMediaRemoteGetNowPlayingClient_t)(dispatch_queue_t queue, MRMediaRemoteGetNowPlayingClientCompletion_t completion);
-typedef void (*MRNowPlayingClientGetParentAppBundleIdentifier_t)(id client, MRNowPlayingClientGetParentAppBundleIdentifierCompletion_t completion);
 typedef void (*MRMediaRemoteGetNowPlayingInfo_t)(dispatch_queue_t queue, MRMediaRemoteGetNowPlayingInfoCompletion_t completion);
 typedef void (*MRMediaRemoteGetNowPlayingApplicationIsPlaying_t)(dispatch_queue_t queue, MRMediaRemoteGetNowPlayingApplicationIsPlayingCompletion_t completion);
 
@@ -154,7 +151,6 @@ extern NSString *kMRNowPlayingClientUserInfoKey;
 // Metadata
 @property(readonly) MRMediaRemoteGetNowPlayingApplicationPID_t getNowPlayingApplicationPID;
 @property(readonly) MRMediaRemoteGetNowPlayingClient_t getNowPlayingClient;
-@property(readonly) MRNowPlayingClientGetParentAppBundleIdentifier_t getNowPlayingClientParentAppBundleIdentifier;
 @property(readonly) MRMediaRemoteGetNowPlayingInfo_t getNowPlayingInfo;
 @property(readonly) MRMediaRemoteGetNowPlayingApplicationIsPlaying_t getNowPlayingApplicationIsPlaying;
 // Constructor

--- a/src/private/MediaRemote.h
+++ b/src/private/MediaRemote.h
@@ -108,6 +108,8 @@ typedef bool (*MRMediaRemoteSetRepeatMode_t)(int mode);
 extern CFStringRef MRMediaRemoteRegisterForNowPlayingNotifications;
 extern CFStringRef MRMediaRemoteUnregisterForNowPlayingNotifications;
 extern CFStringRef MRMediaRemoteGetNowPlayingApplicationPID;
+extern CFStringRef MRMediaRemoteGetNowPlayingClient;
+extern CFStringRef MRNowPlayingClientGetParentAppBundleIdentifier;
 extern CFStringRef MRMediaRemoteGetNowPlayingInfo;
 extern CFStringRef MRMediaRemoteGetNowPlayingApplicationIsPlaying;
 
@@ -116,9 +118,13 @@ typedef void (*MRMediaRemoteUnregisterForNowPlayingNotifications_t)();
 
 typedef void (^MRMediaRemoteGetNowPlayingInfoCompletion_t)(NSDictionary *information);
 typedef void (^MRMediaRemoteGetNowPlayingApplicationPIDCompletion_t)(int PID);
+typedef void (^MRMediaRemoteGetNowPlayingClientCompletion_t)(id clientObj);
+typedef void (^MRNowPlayingClientGetParentAppBundleIdentifierCompletion_t)(NSString *bundleIdentifier);
 typedef void (^MRMediaRemoteGetNowPlayingApplicationIsPlayingCompletion_t)(bool isPlaying);
 
 typedef void (*MRMediaRemoteGetNowPlayingApplicationPID_t)(dispatch_queue_t queue, MRMediaRemoteGetNowPlayingApplicationPIDCompletion_t completion);
+typedef void (*MRMediaRemoteGetNowPlayingClient_t)(dispatch_queue_t queue, MRMediaRemoteGetNowPlayingClientCompletion_t completion);
+typedef void (*MRNowPlayingClientGetParentAppBundleIdentifier_t)(id client, MRNowPlayingClientGetParentAppBundleIdentifierCompletion_t completion);
 typedef void (*MRMediaRemoteGetNowPlayingInfo_t)(dispatch_queue_t queue, MRMediaRemoteGetNowPlayingInfoCompletion_t completion);
 typedef void (*MRMediaRemoteGetNowPlayingApplicationIsPlaying_t)(dispatch_queue_t queue, MRMediaRemoteGetNowPlayingApplicationIsPlayingCompletion_t completion);
 
@@ -147,6 +153,8 @@ extern NSString *kMRNowPlayingClientUserInfoKey;
 @property(readonly) MRMediaRemoteUnregisterForNowPlayingNotifications_t unregisterForNowPlayingNotifications;
 // Metadata
 @property(readonly) MRMediaRemoteGetNowPlayingApplicationPID_t getNowPlayingApplicationPID;
+@property(readonly) MRMediaRemoteGetNowPlayingClient_t getNowPlayingClient;
+@property(readonly) MRNowPlayingClientGetParentAppBundleIdentifier_t getNowPlayingClientParentAppBundleIdentifier;
 @property(readonly) MRMediaRemoteGetNowPlayingInfo_t getNowPlayingInfo;
 @property(readonly) MRMediaRemoteGetNowPlayingApplicationIsPlaying_t getNowPlayingApplicationIsPlaying;
 // Constructor

--- a/src/private/MediaRemote.m
+++ b/src/private/MediaRemote.m
@@ -65,6 +65,8 @@ CFStringRef MRMediaRemoteSetRepeatMode = CFSTR("MRMediaRemoteSetRepeatMode");
 CFStringRef MRMediaRemoteRegisterForNowPlayingNotifications = CFSTR("MRMediaRemoteRegisterForNowPlayingNotifications");
 CFStringRef MRMediaRemoteUnregisterForNowPlayingNotifications = CFSTR("MRMediaRemoteUnregisterForNowPlayingNotifications");
 CFStringRef MRMediaRemoteGetNowPlayingApplicationPID = CFSTR("MRMediaRemoteGetNowPlayingApplicationPID");
+CFStringRef MRMediaRemoteGetNowPlayingClient = CFSTR("MRMediaRemoteGetNowPlayingClient");
+CFStringRef MRNowPlayingClientGetParentAppBundleIdentifier = CFSTR("MRNowPlayingClientGetParentAppBundleIdentifier");
 CFStringRef MRMediaRemoteGetNowPlayingInfo = CFSTR("MRMediaRemoteGetNowPlayingInfo");
 CFStringRef MRMediaRemoteGetNowPlayingApplicationIsPlaying = CFSTR("MRMediaRemoteGetNowPlayingApplicationIsPlaying");
 
@@ -81,6 +83,8 @@ static NSString *MediaRemoteFrameworkBundleURL = @"/System/Library/PrivateFramew
 @synthesize registerForNowPlayingNotifications;
 @synthesize unregisterForNowPlayingNotifications;
 @synthesize getNowPlayingApplicationPID;
+@synthesize getNowPlayingClient;
+@synthesize getNowPlayingClientParentAppBundleIdentifier;
 @synthesize getNowPlayingInfo;
 @synthesize getNowPlayingApplicationIsPlaying;
 -(id)init
@@ -101,6 +105,8 @@ static NSString *MediaRemoteFrameworkBundleURL = @"/System/Library/PrivateFramew
     registerForNowPlayingNotifications = (MRMediaRemoteRegisterForNowPlayingNotifications_t)CFBundleGetFunctionPointerForName(bundle, MRMediaRemoteRegisterForNowPlayingNotifications);
     unregisterForNowPlayingNotifications = (MRMediaRemoteUnregisterForNowPlayingNotifications_t)CFBundleGetFunctionPointerForName(bundle, MRMediaRemoteUnregisterForNowPlayingNotifications);
     getNowPlayingApplicationPID = (MRMediaRemoteGetNowPlayingApplicationPID_t)CFBundleGetFunctionPointerForName(bundle, MRMediaRemoteGetNowPlayingApplicationPID);
+    getNowPlayingClient = (MRMediaRemoteGetNowPlayingClient_t)CFBundleGetFunctionPointerForName(bundle, MRMediaRemoteGetNowPlayingClient);
+    getNowPlayingClientParentAppBundleIdentifier = (MRNowPlayingClientGetParentAppBundleIdentifier_t)CFBundleGetFunctionPointerForName(bundle, MRNowPlayingClientGetParentAppBundleIdentifier);
     getNowPlayingInfo = (MRMediaRemoteGetNowPlayingInfo_t)CFBundleGetFunctionPointerForName(bundle, MRMediaRemoteGetNowPlayingInfo);
     getNowPlayingApplicationIsPlaying = (MRMediaRemoteGetNowPlayingApplicationIsPlaying_t)CFBundleGetFunctionPointerForName(bundle, MRMediaRemoteGetNowPlayingApplicationIsPlaying);
     return self;

--- a/src/private/MediaRemote.m
+++ b/src/private/MediaRemote.m
@@ -66,7 +66,6 @@ CFStringRef MRMediaRemoteRegisterForNowPlayingNotifications = CFSTR("MRMediaRemo
 CFStringRef MRMediaRemoteUnregisterForNowPlayingNotifications = CFSTR("MRMediaRemoteUnregisterForNowPlayingNotifications");
 CFStringRef MRMediaRemoteGetNowPlayingApplicationPID = CFSTR("MRMediaRemoteGetNowPlayingApplicationPID");
 CFStringRef MRMediaRemoteGetNowPlayingClient = CFSTR("MRMediaRemoteGetNowPlayingClient");
-CFStringRef MRNowPlayingClientGetParentAppBundleIdentifier = CFSTR("MRNowPlayingClientGetParentAppBundleIdentifier");
 CFStringRef MRMediaRemoteGetNowPlayingInfo = CFSTR("MRMediaRemoteGetNowPlayingInfo");
 CFStringRef MRMediaRemoteGetNowPlayingApplicationIsPlaying = CFSTR("MRMediaRemoteGetNowPlayingApplicationIsPlaying");
 
@@ -84,7 +83,6 @@ static NSString *MediaRemoteFrameworkBundleURL = @"/System/Library/PrivateFramew
 @synthesize unregisterForNowPlayingNotifications;
 @synthesize getNowPlayingApplicationPID;
 @synthesize getNowPlayingClient;
-@synthesize getNowPlayingClientParentAppBundleIdentifier;
 @synthesize getNowPlayingInfo;
 @synthesize getNowPlayingApplicationIsPlaying;
 -(id)init
@@ -106,7 +104,6 @@ static NSString *MediaRemoteFrameworkBundleURL = @"/System/Library/PrivateFramew
     unregisterForNowPlayingNotifications = (MRMediaRemoteUnregisterForNowPlayingNotifications_t)CFBundleGetFunctionPointerForName(bundle, MRMediaRemoteUnregisterForNowPlayingNotifications);
     getNowPlayingApplicationPID = (MRMediaRemoteGetNowPlayingApplicationPID_t)CFBundleGetFunctionPointerForName(bundle, MRMediaRemoteGetNowPlayingApplicationPID);
     getNowPlayingClient = (MRMediaRemoteGetNowPlayingClient_t)CFBundleGetFunctionPointerForName(bundle, MRMediaRemoteGetNowPlayingClient);
-    getNowPlayingClientParentAppBundleIdentifier = (MRNowPlayingClientGetParentAppBundleIdentifier_t)CFBundleGetFunctionPointerForName(bundle, MRNowPlayingClientGetParentAppBundleIdentifier);
     getNowPlayingInfo = (MRMediaRemoteGetNowPlayingInfo_t)CFBundleGetFunctionPointerForName(bundle, MRMediaRemoteGetNowPlayingInfo);
     getNowPlayingApplicationIsPlaying = (MRMediaRemoteGetNowPlayingApplicationIsPlaying_t)CFBundleGetFunctionPointerForName(bundle, MRMediaRemoteGetNowPlayingApplicationIsPlaying);
     return self;


### PR DESCRIPTION
This pull request introduces support for retrieving the parent application bundle identifier (with the key `parentAppBundleIdentifier`) in the MediaRemote adapter. This is useful in certain cases where applications use extensions or some other layer of abstraction as the media client like WebKit for WebKit-based browsers. This allows you to determine the bundle identifier of the host app that owns the current session. For example, you can use this to identify which browser application is managing the active media session, where the bundleIdentifier will just return `com.apple.WebKit.GPU`.