### PR TITLE
Add --no-artwork flag to get and stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,11 @@ contains the elapsed time at the time that is stored in `timestamp`.
 | `elapsedTimeNow` | `elapsedTimeNowMicros` | Only present with `--now` |
 | `timestamp`      | `timestampEpochMicros` | Converted to epoch time   |
 
+`--no-artwork`&ensp;Omits the `artworkData` and `artworkMimeType` keys
+from the payload. Useful for consumers that do not render artwork,
+since this avoids emitting several hundred kilobytes of base64-encoded
+image data per update.
+
 ---
 
 ### stream
@@ -268,6 +273,10 @@ This is useful to prevent bursts of smaller updates.
 The default is 0.
 
 `--micros`&ensp;Identical to the `--micros` option of the `get` command.
+
+`--no-artwork`&ensp;Identical to the `--no-artwork` option of the `get`
+command. Particularly useful with `stream`, since it otherwise re-emits
+the full artwork payload on every update.
 
 **Experimental options**
 

--- a/bin/mediaremote-adapter.pl
+++ b/bin/mediaremote-adapter.pl
@@ -61,6 +61,9 @@ OPTIONS:
       "elapsedTime" -> "elapsedTimeMicros"
       "elapsedTimeNow" -> "elapsedTimeNowMicros"
       "timestamp" -> "timestampEpochMicros" (converted to epoch time)
+    --no-artwork: Omits "artworkData" and "artworkMimeType" from the payload.
+      Useful for consumers that do not render artwork, since this avoids
+      emitting several hundred kilobytes of base64 data per update.
     --human-readable, -h: Makes values human-readable. Use only for debugging.
       The JSON output is pretty-printed and the following keys are adapted:
       "artworkData" -> Binary data is truncated to a shorter representation
@@ -196,6 +199,9 @@ elsif ($function_name eq "stream") {
     elsif ($key eq "micros") {
       set_env_option($options, $key);
     }
+    elsif ($key eq "no-artwork") {
+      set_env_option($options, $key);
+    }
     elsif ($key eq "human-readable" || $key eq "h") {
       set_env_option($options, "human-readable");
     }
@@ -212,6 +218,9 @@ elsif ($function_name eq "get") {
   my $options = parse_options(0);
   foreach my $key (keys %{$options}) {
     if ($key eq "micros") {
+      set_env_option($options, $key);
+    }
+    elsif ($key eq "no-artwork") {
       set_env_option($options, $key);
     }
     elsif ($key eq "human-readable" || $key eq "h") {

--- a/src/adapter/get.m
+++ b/src/adapter/get.m
@@ -25,6 +25,9 @@ NSDictionary *internal_get(BOOL isTestMode) {
     NSString *now_option = getEnvOption(@"now");
     __block const bool calculate_now = now_option != nil;
 
+    NSString *no_artwork_option = getEnvOption(@"no-artwork");
+    const bool no_artwork = no_artwork_option != nil;
+
     __block NSMutableDictionary *liveData = [NSMutableDictionary dictionary];
     __block BOOL isFromTestClient = NO;
 
@@ -105,6 +108,11 @@ NSDictionary *internal_get(BOOL isTestMode) {
 
     if (isFromTestClient) {
         return nil;
+    }
+
+    if (no_artwork) {
+        [liveData removeObjectForKey:kMRAArtworkData];
+        [liveData removeObjectForKey:kMRAArtworkMimeType];
     }
 
     if (human_readable) {

--- a/src/adapter/stream.m
+++ b/src/adapter/stream.m
@@ -142,6 +142,7 @@ extern void adapter_stream() {
     }
 
     NSString *no_diff_option = getEnvOption(@"no_diff");
+    NSString *no_artwork_option = getEnvOption(@"no-artwork");
     NSString *micros_option = getEnvOption(@"micros");
     NSString *human_readable_option = getEnvOption(@"human-readable");
 
@@ -172,6 +173,7 @@ extern void adapter_stream() {
         [[Debounce alloc] initWithDelay:(debounce_delay_millis / 1000.0)
                                   queue:g_serialdispatchQueue];
     __block const BOOL no_diff = (no_diff_option != nil);
+    __block const BOOL no_artwork = (no_artwork_option != nil);
     __block const BOOL convert_micros = (micros_option != nil);
     __block const bool human_readable = (human_readable_option != nil);
 
@@ -288,6 +290,10 @@ extern void adapter_stream() {
         }
         NSMutableDictionary *converted =
             convertNowPlayingInformation(information, convert_micros, false);
+        if (no_artwork) {
+            [converted removeObjectForKey:kMRAArtworkData];
+            [converted removeObjectForKey:kMRAArtworkMimeType];
+        }
         // Transfer anything over from the existing live data.
         if (liveData[kMRAProcessIdentifier] != nil) {
             converted[kMRAProcessIdentifier] = liveData[kMRAProcessIdentifier];


### PR DESCRIPTION
## Summary

Adds `--no-artwork` to `get` and `stream`. When set, the adapter omits `artworkData` and `artworkMimeType` from the payload before JSON serialization.

## Motivation

Consumers that don't render artwork (CLI tools, loggers, test harnesses, daemons reacting to play/pause events) currently pay for MediaRemote's full TIFF payload on every event — typically 500 KB – 1 MB per track change, re-emitted mid-track. `--no-artwork` drops typical `stream` events to under a kilobyte.

## Behavior

- Opt-in. Default output unchanged.
- Accepted on `get` and `stream`; rejected on `send`/`seek`/`shuffle`/`repeat`/`speed` (non-zero exit).
- Keys are stripped immediately after the MediaRemote dictionary is converted, so the stream-mode "carry old artwork forward" cache becomes a natural no-op with no second guard.
- The fetch itself is not avoided — `MRMediaRemoteGetNowPlayingInfo` has no options parameter, so the dictionary arrives over XPC regardless. The savings are in base64 encoding, NSString allocation, and stdout throughput.
