### PR TITLE
Preserve fractional playback rates in elapsedTimeNow

### DIFF
--- a/src/adapter/now_playing.m
+++ b/src/adapter/now_playing.m
@@ -38,7 +38,7 @@ NSNumber *getElapsedTimeNow(NSDictionary *information) {
     NSTimeInterval currentEpoch = [[NSDate date] timeIntervalSince1970];
     NSTimeInterval timeDiff = currentEpoch - timestampEpoch;
 
-    int playbackRate = 0;
+    double playbackRate = 0;
     id playbackRateVal = information[kMRMediaRemoteNowPlayingInfoPlaybackRate];
     if ([playbackRateVal isKindOfClass:[NSNumber class]]) {
         playbackRate = [(NSNumber *)playbackRateVal doubleValue];


### PR DESCRIPTION
## Summary

Fixes `elapsedTimeNow` calculation for fractional playback rates.

MediaRemote can report non-integer playback rates. The adapter already exposes that `playbackRate` value correctly, but `getElapsedTimeNow()` stored it in an `int`, truncating rates like `0.9` to `0`.

This changes the local `playbackRate` variable to `double` so elapsed-time estimation preserves fractional speeds.

## Verification

- Built successfully with `cmake --build build`
- Ran `get --now --micros --no-artwork` against the rebuilt framework
- Used YouTube in Safari which can report fractional `playbackRate` values (easiest test is a playback rate like 0.9 which gets truncated to 0)