### PR TITLE
Fix seek and speed commands

### DIFF
--- a/src/adapter/seek.m
+++ b/src/adapter/seek.m
@@ -18,10 +18,7 @@ void adapter_seek(long position) {
         failf(@"Negative values are not allowed: %d", position);
     }
 
-    bool result = g_mediaRemote.setElapsedTime(position / 1000000.0);
-    if (!result) {
-        failf(@"Failed to seek to %d", position);
-    }
+    g_mediaRemote.setElapsedTime(position / 1000000.0);
 
     waitForCommandCompletion();
 }

--- a/src/adapter/speed.m
+++ b/src/adapter/speed.m
@@ -18,10 +18,7 @@ void adapter_speed(int speed) {
         failf(@"Negative values are not allowed: %d", speed);
     }
 
-    bool result = g_mediaRemote.setPlaybackSpeed(speed);
-    if (!result) {
-        failf(@"Failed to set playback speed to %d", speed);
-    }
+    g_mediaRemote.setPlaybackSpeed(speed);
 
     waitForCommandCompletion();
 }

--- a/src/private/MediaRemote.h
+++ b/src/private/MediaRemote.h
@@ -103,8 +103,8 @@ extern CFStringRef MRMediaRemoteSetPlaybackSpeed;
 extern CFStringRef MRMediaRemoteSetElapsedTime;
 extern CFStringRef MRMediaRemoteSetShuffleMode;
 extern CFStringRef MRMediaRemoteSetRepeatMode;
-typedef bool (*MRMediaRemoteSetPlaybackSpeed_t)(int speed);
-typedef bool (*MRMediaRemoteSetElapsedTime_t)(double elapsedTime);
+typedef void (*MRMediaRemoteSetPlaybackSpeed_t)(int speed);
+typedef void (*MRMediaRemoteSetElapsedTime_t)(double elapsedTime);
 typedef bool (*MRMediaRemoteSetShuffleMode_t)(int mode);
 typedef bool (*MRMediaRemoteSetRepeatMode_t)(int mode);
 


### PR DESCRIPTION
Changed the return types from bool to void for the seek and speed functions. Removed the checks that caused the script to crash. This stopped the program from closing before the system could process the commands. Closes #26