### PR TITLE
Remove unused JavaScriptCore framework link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ set_target_properties(
                OUTPUT_NAME "${MEDIAREMOTEADAPTER_FRAMEWORK_NAME}")
 
 target_link_libraries(MediaRemoteAdapter "-framework Foundation"
-                      "-framework AppKit" "-framework JavaScriptCore")
+                      "-framework AppKit")
 
 find_library(UT_FRAMEWORK UniformTypeIdentifiers)
 if(UT_FRAMEWORK)


### PR DESCRIPTION
## Summary
- Drop `-framework JavaScriptCore` from the MediaRemoteAdapter link line.
- No source file references any JavaScriptCore symbol; the link has been a no-op since the initial commit.

## Why
- Reduces ~50 MB of dyld work at every script invocation (JavaScriptCore is one of the heavier system frameworks).
- Shrinks the code mapped into the `/usr/bin/perl` host process — relevant given that anything loaded there inherits the `com.apple.perl5` MediaRemote entitlement.

## Verification
- `otool -L build/MediaRemoteAdapter.framework/MediaRemoteAdapter` no longer shows JavaScriptCore in either `x86_64` or `arm64` slices.
- Smoke-tested `get`, `get --no-artwork --human-readable`, `stream --no-artwork`, and `test` against a live media session — all behave identically.