### PR TITLE
Carry over artworkMimeType alongside artworkData in stream

### DIFF
--- a/src/adapter/stream.m
+++ b/src/adapter/stream.m
@@ -312,6 +312,11 @@ extern void adapter_stream() {
             liveData[kMRAArtworkData] != [NSNull null] &&
             converted[kMRAArtworkData] == nil) {
             converted[kMRAArtworkData] = liveData[kMRAArtworkData];
+            if (liveData[kMRAArtworkMimeType] != nil &&
+                liveData[kMRAArtworkMimeType] != [NSNull null] &&
+                converted[kMRAArtworkMimeType] == nil) {
+                converted[kMRAArtworkMimeType] = liveData[kMRAArtworkMimeType];
+            }
         }
 
         // FIXME Make this neater.


### PR DESCRIPTION
When MediaRemote transiently drops both artwork keys (commonly during timeline seeks), stream.m re-uses the previous artworkData but leaves artworkMimeType to whatever MediaRemote returned — which is also nil. The diff layer then emits `artworkMimeType: null` to the consumer, leaving valid bytes paired with no MIME type.

Carry both keys atomically when the item identity is unchanged, so consumers that dispatch decoders or set Content-Type from the MIME field receive a consistent pair.