### PR TITLE
Fix observer/registration race at stream startup

### DIFF
--- a/src/adapter/stream.m
+++ b/src/adapter/stream.m
@@ -360,10 +360,6 @@ extern void adapter_stream() {
       requestAll();
     };
 
-    // FIXME Is this foolproof? This continues and registers observers
-    // which might intervene with the initial requests.
-    requestAll();
-
     NSNotificationCenter *default_center = [NSNotificationCenter defaultCenter];
     NSNotificationCenter *shared_workscape_notification_center =
         [[NSWorkspace sharedWorkspace] notificationCenter];
@@ -482,6 +478,12 @@ extern void adapter_stream() {
                 }];
 
     g_mediaRemote.registerForNowPlayingNotifications(g_serialdispatchQueue);
+
+    // Issue the initial fetch from the serial queue so its replies are ordered
+    // against any notification handlers that fire during startup.
+    dispatch_async(g_serialdispatchQueue, ^{
+      requestAll();
+    });
 
     CFRunLoopRun();
 


### PR DESCRIPTION
## Summary
 
Moves the initial `requestAll()` in `adapter_stream` to **after** observer registration and `registerForNowPlayingNotifications`, and wraps it in `dispatch_async(g_serialdispatchQueue, ^{ ... })`. Resolves the FIXME at the former `src/adapter/stream.m:363-365`.
 
---
 
## Why
 
The previous order was:
 
1. `requestAll()` — fires four async MediaRemote queries
2. `addObserverForName:` — installs NSNotificationCenter observers
3. `registerForNowPlayingNotifications` — tells mediaremoted to start pushing
With `requestAll()` issued from the calling thread before observers are in place, any notification handler that arrived later raced against the initial query replies on `g_serialdispatchQueue`, with no ordering guarantee between them.
 
---
 
## Fix
 
Observers and the MediaRemote subscription are now installed first, then the initial `requestAll()` is dispatched onto `g_serialdispatchQueue`. Because the queue is serial, the initial fetch and any notification handlers that arrive during startup are interleaved in deterministic FIFO order on the same queue, eliminating the cross-thread race the FIXME described.
 
---
 
## Verification
 
- Compiles clean on `x86_64;arm64`.
- `stream` baseline still emits an initial `{}` snapshot and exits cleanly on `SIGTERM`.
- `get` and `test` commands unaffected (`test` returns 0).
- No behavioural change for steady-state notifications.
 