### PR TITLE
Add --allow-missing-title option for sessions without metadata

### DIFF
--- a/bin/mediaremote-adapter.pl
+++ b/bin/mediaremote-adapter.pl
@@ -64,6 +64,14 @@ OPTIONS:
     --no-artwork: Omits "artworkData" and "artworkMimeType" from the payload.
       Useful for consumers that do not render artwork, since this avoids
       emitting several hundred kilobytes of base64 data per update.
+    --allow-missing-title: Emits sessions whose metadata carries no title,
+      instead of reporting them as "nothing is playing". Some players register
+      a now playing client with an empty metadata dictionary for untagged
+      audio: the PID, the bundle identifier and the playback state are known,
+      only the title is absent. Control Center shows these using the
+      application name; without this option they are indistinguishable from
+      no playback at all. The "title" key is absent from such payloads, so
+      consumers that opt in must handle it being missing.
     --human-readable, -h: Makes values human-readable. Use only for debugging.
       The JSON output is pretty-printed and the following keys are adapted:
       "artworkData" -> Binary data is truncated to a shorter representation
@@ -202,6 +210,9 @@ elsif ($function_name eq "stream") {
     elsif ($key eq "no-artwork") {
       set_env_option($options, $key);
     }
+    elsif ($key eq "allow-missing-title") {
+      set_env_option($options, $key);
+    }
     elsif ($key eq "human-readable" || $key eq "h") {
       set_env_option($options, "human-readable");
     }
@@ -221,6 +232,9 @@ elsif ($function_name eq "get") {
       set_env_option($options, $key);
     }
     elsif ($key eq "no-artwork") {
+      set_env_option($options, $key);
+    }
+    elsif ($key eq "allow-missing-title") {
       set_env_option($options, $key);
     }
     elsif ($key eq "human-readable" || $key eq "h") {

--- a/src/adapter/get.m
+++ b/src/adapter/get.m
@@ -114,7 +114,10 @@ NSDictionary *internal_get(BOOL isTestMode) {
         makePayloadHumanReadable(liveData);
     }
 
-    if (!allMandatoryPayloadKeysSet(liveData)) {
+    NSString *allow_missing_title_option =
+        getEnvOption(@"allow-missing-title");
+    if (!allMandatoryPayloadKeysSetAllowingMissingTitle(
+            liveData, allow_missing_title_option != nil)) {
         return nil;
     }
 

--- a/src/adapter/keys.h
+++ b/src/adapter/keys.h
@@ -9,9 +9,22 @@
 // These keys are mandatory and must never be null, empty or missing.
 NSArray<NSString *> *mandatoryPayloadKeys(void);
 
+// The mandatory keys for media without a title, i.e. everything returned by
+// mandatoryPayloadKeys() except the title. Used when the caller opts into
+// receiving sessions whose metadata carries no title (see the
+// "allow-missing-title" option), which some players produce for untagged
+// audio: the now playing client, its PID and its playback state are all
+// known, only the metadata dictionary is empty.
+NSArray<NSString *> *mandatoryPayloadKeysWithoutTitle(void);
+
 // Checks whether all mandatory payload keys returned by mandatoryPayloadKeys()
 // are present in the given payload dictionary and have a non-null value.
 bool allMandatoryPayloadKeysSet(NSDictionary *data);
+
+// Same as allMandatoryPayloadKeysSet(), but the title is not required when
+// allowMissingTitle is true.
+bool allMandatoryPayloadKeysSetAllowingMissingTitle(NSDictionary *data,
+                                                    bool allowMissingTitle);
 
 // These keys identify a now playing item uniquely.
 NSArray<NSString *> *identifyingPayloadKeys(void);

--- a/src/adapter/keys.m
+++ b/src/adapter/keys.m
@@ -60,8 +60,19 @@ NSArray<NSString *> *mandatoryPayloadKeys(void) {
     return @[ kMRAProcessIdentifier, kMRATitle, kMRAPlaying ];
 }
 
+NSArray<NSString *> *mandatoryPayloadKeysWithoutTitle(void) {
+    return @[ kMRAProcessIdentifier, kMRAPlaying ];
+}
+
 bool allMandatoryPayloadKeysSet(NSDictionary *data) {
-    NSArray<NSString *> *keys = mandatoryPayloadKeys();
+    return allMandatoryPayloadKeysSetAllowingMissingTitle(data, false);
+}
+
+bool allMandatoryPayloadKeysSetAllowingMissingTitle(NSDictionary *data,
+                                                    bool allowMissingTitle) {
+    NSArray<NSString *> *keys = allowMissingTitle
+                                    ? mandatoryPayloadKeysWithoutTitle()
+                                    : mandatoryPayloadKeys();
     for (NSString *key in keys) {
         if (data[key] == nil || data[key] == [NSNull null]) {
             return false;

--- a/src/adapter/stream.m
+++ b/src/adapter/stream.m
@@ -164,6 +164,8 @@ extern void adapter_stream() {
     NSString *no_artwork_option = getEnvOption(@"no-artwork");
     NSString *micros_option = getEnvOption(@"micros");
     NSString *human_readable_option = getEnvOption(@"human-readable");
+    NSString *allow_missing_title_option =
+        getEnvOption(@"allow-missing-title");
 
     // This option is needed for media players which, when changing tracks,
     // update the artist and/or other fields later than e.g. the title, the
@@ -195,13 +197,20 @@ extern void adapter_stream() {
     __block const BOOL no_artwork = (no_artwork_option != nil);
     __block const BOOL convert_micros = (micros_option != nil);
     __block const bool human_readable = (human_readable_option != nil);
+    // Players that hand MediaRemote an empty metadata dictionary (untagged
+    // audio, e.g. a file shared in a chat client) still register a now playing
+    // client with a PID and a playback state. Without this option such a
+    // session is indistinguishable from "nothing is playing", even though
+    // Control Center shows it, using the application name as the label.
+    __block const bool allow_missing_title = (allow_missing_title_option != nil);
 
     void (^localPrintData)(NSDictionary *) = ^(NSDictionary *data) {
       printData(data, !no_diff, human_readable);
     };
 
     void (^directHandle)() = ^() {
-      if (allMandatoryPayloadKeysSet(liveData)) {
+      if (allMandatoryPayloadKeysSetAllowingMissingTitle(liveData,
+                                                        allow_missing_title)) {
           if (human_readable) {
               NSMutableDictionary *shallowClone =
                   [NSMutableDictionary dictionaryWithDictionary:liveData];


### PR DESCRIPTION
Fixes #39.

## Problem

A player can register a now playing client whose metadata dictionary is empty. The PID, the bundle identifier and the playback state are all known — only the title is missing. Because `kMRATitle` is one of `mandatoryPayloadKeys()`, `allMandatoryPayloadKeysSet()` fails and the whole session is dropped: `stream` prints `payload:{}` and `get` returns `null`, indistinguishable from no playback at all.

Control Center shows these sessions, using the application name as the label, so consumers currently cannot match its behaviour.

Reproduced with Telegram (`com.tdesktop.Telegram`) playing an untagged audio file on macOS 26.6.1 — see #39 for the full trace.

## Change

Adds an opt-in `--allow-missing-title` option to `get` and `stream`:

- `keys.h/.m`: `mandatoryPayloadKeysWithoutTitle()` plus `allMandatoryPayloadKeysSetAllowingMissingTitle(data, allowMissingTitle)`. The existing `allMandatoryPayloadKeysSet()` keeps its signature and delegates with `false`, so no caller changes behaviour.
- `stream.m` / `get.m`: read the option and pass it through.
- `bin/mediaremote-adapter.pl`: accept and document the flag for both commands.

**Default behaviour is unchanged.** Consumers that opt in must handle `title` being absent from the payload; the documentation says so explicitly.

## Verification

Built the framework and ran it against the reproduction case (same Telegram session, audio playing):

```
# before / default
$ ... get --micros --no-artwork
null

# with the flag
$ ... get --micros --no-artwork --allow-missing-title
{"playing":false,"processIdentifier":35449,"bundleIdentifier":"com.tdesktop.Telegram"}
```

Tagged media is byte-for-byte unaffected with and without the flag, and a genuinely empty session (nothing playing) still yields `null` / `payload:{}` because the PID and playback state are absent too.

I'm consuming this downstream in a notch app, where it restores the Control-Center-style "app name + transport controls" fallback for untagged audio. Glad to rename the option or rework the approach if you'd rather solve it another way.
